### PR TITLE
Updates copyright year to 2025 in pipeline templates

### DIFF
--- a/pipelines/lib/azure-cli.yml
+++ b/pipelines/lib/azure-cli.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Vladimir Gusarov. All rights reserved.
+# Copyright (c) 2025 Vladimir Gusarov. All rights reserved.
 # Licensed under the MIT License.
 #
 # Template: Azure CLI Template

--- a/pipelines/lib/bicep-deploy.yml
+++ b/pipelines/lib/bicep-deploy.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Vladimir Gusarov. All rights reserved.
+# Copyright (c) 2025 Vladimir Gusarov. All rights reserved.
 # Licensed under the MIT License.
 
 # Bicep Deployment Pipeline Template

--- a/pipelines/lib/docker.yml
+++ b/pipelines/lib/docker.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Vladimir Gusarov. All rights reserved.
+# Copyright (c) 2025 Vladimir Gusarov. All rights reserved.
 # Licensed under the MIT License.
 #
 # Template: Docker Build Pipeline


### PR DESCRIPTION
This pull request updates copyright years in several pipeline template files to reflect the year 2025.

- [`pipelines/lib/azure-cli.yml`](diffhunk://#diff-a410c38d46d0bff007574c14a875e48412f30a25a8fdd659c0cd7f898870e058L1-R1): Updated copyright year from 2023 to 2025.
- [`pipelines/lib/bicep-deploy.yml`](diffhunk://#diff-ae974f4c972642f7c2fe997bb2f3cdc8370e5503e803d5c5daf2ff540e102636L1-R1): Updated copyright year from 2023 to 2025.
- [`pipelines/lib/docker.yml`](diffhunk://#diff-2b6dffb6edd37b35d531a2e5978f4a003d55887ef7e24b3750d82c099f1c6c63L1-R1): Updated copyright year from 2023 to 2025.