### PR TITLE
Fix GitHub repo references

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ resources:
   - repository: templates
     type: github
     name: almguru/build-templates
-    endpoint: MyGitHubServiceConnection 
+    endpoint: MyGitHubServiceConnection
     ref: main
 
 stages:


### PR DESCRIPTION
This pull request updates the `README.md` file to replace references to `git` with `github` for repository types and adds a new `endpoint` field pointing to `MyGitHubServiceConnection`. These changes ensure better integration with GitHub repositories.

Key changes:

### Repository Type Update:
* Updated the repository type from `git` to `github` in multiple sections of the `README.md` file to align with GitHub integration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L138-R140) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L166-R169) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L223-R227) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L259-R264)

### GitHub Service Connection:
* Added the `endpoint` field with the value `MyGitHubServiceConnection` to specify the service connection for GitHub repositories. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L138-R140) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L166-R169) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L223-R227) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L259-R264)