### PR TITLE
Refactor bicep-deploy to BicepDeploy@0 with stack support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -75,6 +75,11 @@ Templates support three feed strategies via `feedsToUse` parameter:
 - Use `$(System.*)` and `$(Build.*)` variables from Azure DevOps context
 - **Conditions** in templates use `${{ if condition }}` syntax for compile-time logic
 
+### 6. PowerShell Script Standards
+- Use approved Verb-Noun naming for script filenames (for example, `ConvertTo-*`, `Invoke-*`, `Set-*`)
+- Prefer explicit script parameters over hidden environment-variable inputs when practical
+- Always include and keep current inline documentation for PowerShell scripts (comment-based help with `.SYNOPSIS`, `.DESCRIPTION`, and `.PARAMETER` sections)
+
 ## Integration Points and Dependencies
 
 ### Required Repository Setup
@@ -116,5 +121,6 @@ When adding or modifying templates:
 - **Document parameter examples** in template comments (shows up in pipeline UI)
 - **Use stepList for extensibility** - Provide `before*Steps` hooks so consumers can inject custom logic
 - **Validate early** - Check parameter combinations in template steps (see `azure-cli.yml` verification pattern)
+- **Validate after every edit** - Re-check any file you changed for syntax, formatting, and template expression correctness before finishing
 - **Test parameter coverage** - Add test cases in `azure-pipelines.yml` for new parameter combinations
 - **Use consistent naming** - Follow verb-noun convention for step display names and parameter names

--- a/pipelines/lib/README.md
+++ b/pipelines/lib/README.md
@@ -273,7 +273,7 @@ Template for deploying Azure Bicep templates across different scopes (Subscripti
 - **Variable Naming:** Follows structured naming convention: `{deploymentOutputs}.{outputName}.name` and `{deploymentOutputs}.{outputName}.value`
 - **Error Handling:** Comprehensive error handling and validation
 
-> **Note:** This template expects template files to be checked out via `use-template-files.yml` so helper scripts are available. Run `use-template-files.yml` once per job before templates that depend on template files.
+> **Note:** `use-template-files.yml` is required only when `useLegacyOverrideParameters: true` (legacy `key=value` conversion uses helper scripts). When `useLegacyOverrideParameters: false`, this template can run without checking out template files.
 
 For stack-specific input semantics and valid values, refer to the official [`BicepDeploy@0` task documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/bicep-deploy-v0?view=azure-pipelines).
 

--- a/pipelines/lib/README.md
+++ b/pipelines/lib/README.md
@@ -248,7 +248,7 @@ Template for deploying Azure Bicep templates across different scopes (Subscripti
 | `file` | string | Required | Path to the Bicep file to deploy |
 | `overrideParameters` | string | `""` | Override parameters for deployment |
 | `useLegacyOverrideParameters` | boolean | `true` | Whether to parse `overrideParameters` as legacy `key=value` syntax. Set to `false` to pass native JSON/YAML object string directly to `BicepDeploy@0` |
-| `deploymentOutputs` | string | `"Bicep"` | Prefix for output variables |
+| `deploymentOutputs` | string | `"Bicep"` | Prefix for output variables (allowed chars: letters, digits, underscore, dot, hyphen) |
 | `actionOnUnmanageResources` | string | `""` | Deployment stack only: optional passthrough to `BicepDeploy@0` `actionOnUnmanageResources` |
 | `actionOnUnmanageResourceGroups` | string | `""` | Deployment stack only: passthrough to `BicepDeploy@0` `actionOnUnmanageResourceGroups` |
 | `actionOnUnmanageManagementGroups` | string | `""` | Deployment stack only: passthrough to `BicepDeploy@0` `actionOnUnmanageManagementGroups` |

--- a/pipelines/lib/README.md
+++ b/pipelines/lib/README.md
@@ -228,37 +228,74 @@ A reusable template for executing Azure CLI commands in Azure DevOps pipelines w
 
 **Location:** `pipelines/lib/bicep-deploy.yml`
 
-Template for deploying Azure Bicep templates across different scopes (Subscription, Resource Group, Management Group, or Tenant) with parameter override support and automatic output variable creation.
+Template for deploying Azure Bicep templates across different scopes (Subscription, Resource Group, Management Group, or Tenant) using [`BicepDeploy@0`](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/bicep-deploy-v0?view=azure-pipelines), while preserving backward-compatible parameter and output behavior.
 
 ### Parameters
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `azureSubscription` | string | Required | Azure service connection name |
+| `type` | string | `""` | Optional passthrough to `BicepDeploy@0` `type` input. When empty, task default is used |
+| `operation` | string | `""` | Optional passthrough to `BicepDeploy@0` `operation` input. When empty, task default is used |
 | `deploymentScope` | string | `'Subscription'` | Deployment scope (`Subscription`, `ResourceGroup`, `ManagementGroup`, `Tenant`) |
 | `deploymentName` | string | `"Bicep-Deploy-$(System.DefinitionId)-$(Build.BuildId)-$(System.JobAttempt)"` | Name for the deployment |
+| `deploymentDescription` | string | `"Deployed by $(Build.DefinitionName) build $(Build.BuildNumber)"` | Description written to Azure deployment history |
 | `location` | string | Required* | Azure location for Subscription/Management Group/Tenant scopes |
+| `subscriptionId` | string | `""` | Optional subscription ID for `ResourceGroup`/`Subscription` scopes (auto-resolved when omitted) |
 | `resourceGroupName` | string | `"rg-my-resource-group"` | Resource group name for ResourceGroup scope |
 | `managementGroupId` | string | `"mg-my-management-group"` | Management group ID for ManagementGroup scope |
+| `tenantId` | string | `""` | Optional tenant ID for `Tenant` scope (auto-resolved when omitted) |
 | `file` | string | Required | Path to the Bicep file to deploy |
 | `overrideParameters` | string | `""` | Override parameters for deployment |
+| `useLegacyOverrideParameters` | boolean | `true` | Whether to parse `overrideParameters` as legacy `key=value` syntax. Set to `false` to pass native JSON/YAML object string directly to `BicepDeploy@0` |
 | `deploymentOutputs` | string | `"Bicep"` | Prefix for output variables |
+| `actionOnUnmanageResources` | string | `""` | Deployment stack only: optional passthrough to `BicepDeploy@0` `actionOnUnmanageResources` |
+| `actionOnUnmanageResourceGroups` | string | `""` | Deployment stack only: passthrough to `BicepDeploy@0` `actionOnUnmanageResourceGroups` |
+| `actionOnUnmanageManagementGroups` | string | `""` | Deployment stack only: passthrough to `BicepDeploy@0` `actionOnUnmanageManagementGroups` |
+| `denySettingsMode` | string | `""` | Deployment stack only: optional passthrough to `BicepDeploy@0` `denySettingsMode` |
+| `denySettingsExcludedActions` | string | `""` | Deployment stack only: passthrough to `BicepDeploy@0` `denySettingsExcludedActions` |
+| `denySettingsExcludedPrincipals` | string | `""` | Deployment stack only: passthrough to `BicepDeploy@0` `denySettingsExcludedPrincipals` |
+| `denySettingsApplyToChildScopes` | boolean | `false` | Deployment stack only: passthrough to `BicepDeploy@0` `denySettingsApplyToChildScopes` |
+| `bypassStackOutOfSyncError` | string | `""` | Deployment stack only: optional passthrough to `BicepDeploy@0` `bypassStackOutOfSyncError` (`true`/`false`) |
+| `stackTags` | string | `""` | Deployment stack only: passthrough to `BicepDeploy@0` `tags` (JSON/YAML object string) |
 
 *Required for Subscription, Management Group, and Tenant scopes
 
 ### Features
 
+- **Native Bicep Task:** Uses Azure DevOps `BicepDeploy@0` for deployments
+- **Deployment Stack Support:** Supports `type: deploymentStack` with stack lifecycle controls
 - **Multi-Scope Deployment:** Supports all Azure deployment scopes
-- **Parameter Processing:** Advanced parameter parsing with JSON support and proper escaping
+- **Parameter Processing:** Uses a single `overrideParameters` input with a legacy parsing switch (`useLegacyOverrideParameters`)
+- **Scripted Parameter Preparation:** Uses `scripts/ConvertTo-BicepDeploymentParametersJson.ps1` only for legacy `key=value` conversion
 - **Output Variables:** Automatically creates Azure DevOps variables from Bicep outputs
+- **Native Task Outputs:** Exposes `BicepDeploy@0` output variables (preferred format: `$(bicepDeploy.<outputName>)`)
 - **Variable Naming:** Follows structured naming convention: `{deploymentOutputs}.{outputName}.name` and `{deploymentOutputs}.{outputName}.value`
-- **Portal Integration:** Provides deployment details URL for Azure Portal
 - **Error Handling:** Comprehensive error handling and validation
+
+> **Note:** This template expects template files to be checked out via `use-template-files.yml` so helper scripts are available. Run `use-template-files.yml` once per job before templates that depend on template files.
+
+For stack-specific input semantics and valid values, refer to the official [`BicepDeploy@0` task documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/bicep-deploy-v0?view=azure-pipelines).
 
 ### Parameter Override Examples
 
 ```yaml
+# Preferred: native JSON object passed directly to BicepDeploy@0
+useLegacyOverrideParameters: false
+overrideParameters: |
+  {
+    "environmentName": "$(environmentName)",
+    "location": "$(environmentLocation)"
+  }
+
+# Also supported: native YAML object passed directly to BicepDeploy@0
+useLegacyOverrideParameters: false
+overrideParameters: |
+  environmentName: "$(environmentName)"
+  location: "$(environmentLocation)"
+
 # Simple parameters
+useLegacyOverrideParameters: true
 overrideParameters: 'environmentName=production resourceGroupName=myRG'
 
 # JSON parameter with escaped quotes
@@ -271,17 +308,25 @@ overrideParameters: 'settings={`"logging`":{`"level`":`"info`",`"enabled`":true}
 overrideParameters: 'env=prod tags="{\"project\":\"app\",\"team\":\"engineering\"}" debug=false'
 ```
 
+`overrideParameters` is converted only when `useLegacyOverrideParameters` is `true`. When it is `false`, the value is passed directly to `BicepDeploy@0` and can be either JSON or YAML as documented in [Override parameters](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/bicep-deploy-v0?view=azure-pipelines#override-parameters).
+
 ### Output Variables
 
-The template automatically creates pipeline variables from Bicep deployment outputs:
-- **Individual Variables:** `{deploymentOutputs}.{outputName}.name` and `{deploymentOutputs}.{outputName}.value`
+The template exposes deployment outputs in two formats:
+- **Preferred (native `BicepDeploy@0` outputs):** `$(bicepDeploy.<outputName>)` (see [BicepDeploy@0 output usage](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/bicep-deploy-v0?view=azure-pipelines#deployment-outputs))
+- **Backward-compatible aliases:** `{deploymentOutputs}.{outputName}.name` and `{deploymentOutputs}.{outputName}.value`, derived from native `BicepDeploy@0` output variables (**deprecated**; scheduled for removal in the next major template version)
 - **Consolidated JSON:** Single variable with the `deploymentOutputs` parameter name containing all outputs as JSON
 
 ### Usage Examples
 
+For full task syntax and options, see the official [`BicepDeploy@0` task documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/bicep-deploy-v0?view=azure-pipelines).
+
 #### Resource Group Deployment
 
 ```yaml
+# Required: make template helper scripts available
+- template: pipelines/lib/use-template-files.yml@almguru-templates
+
 - template: pipelines/lib/bicep-deploy.yml@almguru-templates
   parameters:
     azureSubscription: 'my-azure-connection'
@@ -293,14 +338,22 @@ The template automatically creates pipeline variables from Bicep deployment outp
 
 # Use outputs from previous deployment
 - script: |
-    echo "Storage Account: $(Infrastructure.storageAccountName.value)"
-    echo "App Service URL: $(Infrastructure.appServiceUrl.value)"
+    # Preferred format (native BicepDeploy task outputs)
+    echo "Storage Account: $(bicepDeploy.storageAccountName)"
+    echo "App Service URL: $(bicepDeploy.appServiceUrl)"
+
+    # Backward-compatible aliases
+    echo "Storage Account (legacy): $(Infrastructure.storageAccountName.value)"
+    echo "App Service URL (legacy): $(Infrastructure.appServiceUrl.value)"
   displayName: 'Display Deployment Outputs'
 ```
 
 #### Subscription Scope Deployment
 
 ```yaml
+# Required: make template helper scripts available
+- template: pipelines/lib/use-template-files.yml@almguru-templates
+
 - template: pipelines/lib/bicep-deploy.yml@almguru-templates
   parameters:
     azureSubscription: 'my-azure-connection'
@@ -313,6 +366,9 @@ The template automatically creates pipeline variables from Bicep deployment outp
 #### Management Group Scope Deployment
 
 ```yaml
+# Required: make template helper scripts available
+- template: pipelines/lib/use-template-files.yml@almguru-templates
+
 - template: pipelines/lib/bicep-deploy.yml@almguru-templates
   parameters:
     azureSubscription: 'my-azure-connection'
@@ -320,6 +376,50 @@ The template automatically creates pipeline variables from Bicep deployment outp
     managementGroupId: 'mg-production'
     location: 'eastus'
     file: 'infrastructure/management-group.bicep'
+```
+
+#### Deployment Stack Create/Update (Resource Group Scope)
+
+```yaml
+# Required: make template helper scripts available
+- template: pipelines/lib/use-template-files.yml@almguru-templates
+
+- template: pipelines/lib/bicep-deploy.yml@almguru-templates
+  parameters:
+    azureSubscription: 'my-azure-connection'
+    type: 'deploymentStack'
+    operation: 'create'
+    deploymentScope: 'ResourceGroup'
+    resourceGroupName: 'my-resource-group'
+    file: 'infrastructure/main.bicep'
+    useLegacyOverrideParameters: false
+    overrideParameters: |
+      environmentName: production
+      location: eastus
+    actionOnUnmanageResources: 'detach'
+    denySettingsMode: 'denyDelete'
+    denySettingsExcludedPrincipals: '00000000-0000-0000-0000-000000000000'
+    stackTags: |
+      Environment: Production
+      Owner: PlatformTeam
+```
+
+#### Deployment Stack Delete (Resource Group Scope)
+
+```yaml
+# Required: make template helper scripts available
+- template: pipelines/lib/use-template-files.yml@almguru-templates
+
+- template: pipelines/lib/bicep-deploy.yml@almguru-templates
+  parameters:
+    azureSubscription: 'my-azure-connection'
+    type: 'deploymentStack'
+    operation: 'delete'
+    deploymentScope: 'ResourceGroup'
+    resourceGroupName: 'my-resource-group'
+    deploymentName: 'production-stack'
+    file: 'infrastructure/main.bicep'
+    useLegacyOverrideParameters: false
 ```
 
 ## Docker Build Template
@@ -487,7 +587,7 @@ Template for checking out template repository files to make scripts and resource
 ### Usage Example
 
 ```yaml
-# Must be called before other templates that require template files
+# Must be called once per job before templates that require template files
 - template: pipelines/lib/use-template-files.yml@almguru-templates
   parameters:
     repositoryResourceName: 'almguru-templates'
@@ -555,6 +655,8 @@ stages:
   - job: DeployInfrastructure
     displayName: 'Deploy Infrastructure'
     steps:
+    - template: pipelines/lib/use-template-files.yml@almguru-templates
+
     # Deploy infrastructure using Bicep
     - template: pipelines/lib/bicep-deploy.yml@almguru-templates
       parameters:
@@ -574,8 +676,8 @@ stages:
           location: 'inlineScript'
           script: |
             # Use outputs from Bicep deployment
-            APP_SERVICE_NAME=$(Infrastructure.appServiceName.value)
-            CONTAINER_REGISTRY=$(Infrastructure.containerRegistry.value)
+            APP_SERVICE_NAME=$(bicepDeploy.appServiceName)
+            CONTAINER_REGISTRY=$(bicepDeploy.containerRegistry)
             
             # Deploy container to App Service
             az webapp config container set \
@@ -624,6 +726,8 @@ stages:
   jobs:
   - job: Deploy
     steps:
+    - template: pipelines/lib/use-template-files.yml@almguru-templates
+
     - template: pipelines/lib/bicep-deploy.yml@almguru-templates
       parameters:
         azureSubscription: 'azure-dev-connection'
@@ -657,6 +761,8 @@ stages:
   jobs:
   - job: Deploy
     steps:
+    - template: pipelines/lib/use-template-files.yml@almguru-templates
+
     - template: pipelines/lib/bicep-deploy.yml@almguru-templates
       parameters:
         azureSubscription: 'azure-prod-connection'

--- a/pipelines/lib/bicep-deploy.yml
+++ b/pipelines/lib/bicep-deploy.yml
@@ -311,10 +311,23 @@ steps:
       $outputs[$outputName] = @{ value = $outputVar.Value }
     }
 
+    function Assert-SafeAzureDevOpsVariableName {
+      param(
+        [Parameter(Mandatory = $true)]
+        [string] $Name
+      )
+
+      # Allow only characters that are safe in Azure DevOps logging commands.
+      if ($Name -notmatch '^[A-Za-z0-9_.-]+$') {
+        throw "Unsafe Azure DevOps variable name detected: '$Name'. Allowed characters: letters, digits, underscore, dot, hyphen."
+      }
+    }
+
     Write-Host "##[group]Build legacy output variables"
     Write-Host "BicepDeploy outputs discovered: $($outputs.Keys -join ', ')"
 
     $allOutputsVariableName = "${{ parameters.deploymentOutputs }}"
+    Assert-SafeAzureDevOpsVariableName -Name $allOutputsVariableName
     $allOutputsJson = $outputs | ConvertTo-Json -Compress -Depth 100
     Write-Host "##vso[task.setvariable variable=$allOutputsVariableName]$allOutputsJson"
 
@@ -324,6 +337,8 @@ steps:
 
       $nameVariableName = "$allOutputsVariableName.$outputName.name"
       $valueVariableName = "$allOutputsVariableName.$outputName.value"
+      Assert-SafeAzureDevOpsVariableName -Name $nameVariableName
+      Assert-SafeAzureDevOpsVariableName -Name $valueVariableName
 
       Write-Host "##vso[task.setvariable variable=$nameVariableName]$outputName"
       Write-Host "##vso[task.setvariable variable=$valueVariableName]$outputValue"

--- a/pipelines/lib/bicep-deploy.yml
+++ b/pipelines/lib/bicep-deploy.yml
@@ -326,7 +326,7 @@ steps:
     Write-Host "##[group]Build legacy output variables"
     Write-Host "BicepDeploy outputs discovered: $($outputs.Keys -join ', ')"
 
-    $allOutputsVariableName = "${{ parameters.deploymentOutputs }}"
+    $allOutputsVariableName = $env:LEGACY_DEPLOYMENT_OUTPUTS_VARIABLE
     Assert-SafeAzureDevOpsVariableName -Name $allOutputsVariableName
     $allOutputsJson = $outputs | ConvertTo-Json -Compress -Depth 100
     Write-Host "##vso[task.setvariable variable=$allOutputsVariableName]$allOutputsJson"
@@ -346,3 +346,5 @@ steps:
 
     Write-Host "##[endgroup]"
   displayName: "Build legacy output variables"
+  env:
+    LEGACY_DEPLOYMENT_OUTPUTS_VARIABLE: ${{ parameters.deploymentOutputs }}

--- a/pipelines/lib/bicep-deploy.yml
+++ b/pipelines/lib/bicep-deploy.yml
@@ -6,16 +6,16 @@
 #
 # Description:
 #   This reusable pipeline template deploys Azure resources using Bicep templates across
-#   multiple deployment scopes (Subscription, Resource Group, Management Group, or Tenant).
-#   It automatically converts Bicep deployment outputs to Azure DevOps pipeline variables,
-#   similar to the AzureResourceGroupDeployment@2 task behavior.
+#   multiple deployment scopes (Subscription, Resource Group, Management Group, or Tenant)
+#   via BicepDeploy@0.
+#   It preserves the previous output variable contract for backward compatibility.
 #
 # Key Features:
-#   - Multi-scope deployment support (Subscription, Resource Group, Management Group, Tenant)
-#   - Advanced parameter parsing with JSON support and special character escaping
-#   - Automatic output variable generation with structured naming convention
-#   - Compatible with existing Azure DevOps deployment patterns
-#   - Comprehensive error handling and deployment validation
+#   - Native BicepDeploy@0 support for multi-scope deployments
+#   - Optional Azure Deployment Stack support with stack-specific controls
+#   - Legacy override parameter parsing switch via useLegacyOverrideParameters
+#   - Backward-compatible output variable generation
+#   - Automatic subscription/tenant resolution when not explicitly provided
 #
 # Variable Naming Convention:
 #   - All outputs are prefixed with the deploymentOutputs parameter (default: "Bicep")
@@ -29,6 +29,21 @@
 # Parameter Examples:
 #   # Simple parameters
 #   overrideParameters: 'environmentName=production resourceGroupName=myRG'
+#   useLegacyOverrideParameters: true
+#   
+#   # JSON object passed directly to BicepDeploy@0
+#   useLegacyOverrideParameters: false
+#   overrideParameters: |
+#     {
+#       "environmentName": "production",
+#       "location": "eastus"
+#     }
+#
+#   # YAML object passed directly to BicepDeploy@0
+#   useLegacyOverrideParameters: false
+#   overrideParameters: |
+#     environmentName: production
+#     location: eastus
 #   
 #   # JSON parameters with escaped quotes
 #   overrideParameters: 'config="{\"database\":{\"name\":\"db\",\"tier\":\"premium\"}}"'
@@ -49,6 +64,18 @@ parameters:
 - name: azureSubscription
   type: string
 
+# Optional execution type for BicepDeploy@0.
+# When empty, BicepDeploy@0 default is used.
+- name: type
+  type: string
+  default: ""
+
+# Optional operation for BicepDeploy@0.
+# When empty, BicepDeploy@0 default is used.
+- name: operation
+  type: string
+  default: ""
+
 # Deployment scope for the Bicep deployment
 - name: deploymentScope
   type: string
@@ -64,9 +91,20 @@ parameters:
   type: string
   default: "Bicep-Deploy-$(System.DefinitionId)-$(Build.BuildId)-$(System.JobAttempt)"
 
+# Deployment description for Azure deployment history
+- name: deploymentDescription
+  type: string
+  default: "Deployed by $(Build.DefinitionName) build $(Build.BuildNumber)"
+
 # Geographical Azure Location for Subscription and Management Group scopes
 - name: location 
   type: string
+
+# Subscription ID for ResourceGroup and Subscription scopes.
+# If omitted, it will be resolved automatically from the service connection.
+- name: subscriptionId
+  type: string
+  default: ""
 
 # Resource Group name for Resource Group scope
 - name: resourceGroupName
@@ -78,6 +116,12 @@ parameters:
   type: string
   default: "mg-my-management-group"
 
+# Tenant ID for Tenant scope.
+# If omitted, it will be resolved automatically from the service connection.
+- name: tenantId
+  type: string
+  default: ""
+
 # Bicep file to deploy
 - name: file
   type: string
@@ -87,248 +131,203 @@ parameters:
   type: string
   default: ""
 
+# Whether to parse overrideParameters as legacy key=value input.
+# - true: parse legacy key=value syntax (backward-compatible behavior)
+# - false: pass overrideParameters directly as JSON/YAML object string
+- name: useLegacyOverrideParameters
+  type: boolean
+  default: true
+
 # Bicep deployment outputs variable name
 - name: deploymentOutputs
   type: string
   default: "Bicep"
 
-steps:      
+# Stack only: action for unmanaged resources
+- name: actionOnUnmanageResources
+  type: string
+  default: ""
+
+# Stack only: action for unmanaged resource groups
+- name: actionOnUnmanageResourceGroups
+  type: string
+  default: ""
+
+# Stack only: action for unmanaged management groups
+- name: actionOnUnmanageManagementGroups
+  type: string
+  default: ""
+
+# Stack only: deny settings mode
+- name: denySettingsMode
+  type: string
+  default: ""
+
+# Stack only: comma-separated action names excluded from deny settings
+- name: denySettingsExcludedActions
+  type: string
+  default: ""
+
+# Stack only: comma-separated principal object IDs excluded from deny settings
+- name: denySettingsExcludedPrincipals
+  type: string
+  default: ""
+
+# Stack only: apply deny settings to child scopes
+- name: denySettingsApplyToChildScopes
+  type: boolean
+  default: false
+
+# Stack only: bypass stack out-of-sync error
+- name: bypassStackOutOfSyncError
+  type: string
+  default: ""
+
+# Stack only: tags object in JSON or YAML string format
+- name: stackTags
+  type: string
+  default: ""
+
+steps:
+- pwsh: |
+    Write-Host "##vso[task.logissue type=error]Template resource files are not configured. Make sure to call `use-template-files.yml` first."
+    exit 1
+  condition: and(succeeded(), eq(variables.almguruTemplateFilesPath, ''))
+  displayName: "Fail if template files are not configured"
+
+- ${{ if parameters.useLegacyOverrideParameters }}:
+  - template: azure-cli.yml
+    parameters:
+      azureSubscription: ${{ parameters.azureSubscription }}
+      defaultScriptType: "pscore"
+      script:
+        type: "pscore"
+        script: |
+          $ErrorActionPreference = "Stop"
+          $parametersJson = & "$(almguruTemplateFilesPath)/scripts/ConvertTo-BicepDeploymentParametersJson.ps1" `
+            -OverrideParameters '${{ replace(parameters.overrideParameters, '''', '''''') }}'
+          Write-Host "##vso[task.setvariable variable=BicepDeploy.ParametersJson]$parametersJson"
+        displayName: "Convert legacy deployment parameters"
+
+- ${{ if not(parameters.useLegacyOverrideParameters) }}:
+  - pwsh: |
+      $parametersJson = @'
+      ${{ parameters.overrideParameters }}
+      '@.Trim()
+      Write-Host "##vso[task.setvariable variable=BicepDeploy.ParametersJson]$parametersJson"
+    displayName: "Prepare deployment parameters (structured format)"
+
 - template: azure-cli.yml
+  condition: and(succeeded(), or(and(or(eq('${{ parameters.deploymentScope }}', 'ResourceGroup'), eq('${{ parameters.deploymentScope }}', 'Subscription')), eq('${{ parameters.subscriptionId }}', '')), and(eq('${{ parameters.deploymentScope }}', 'Tenant'), eq('${{ parameters.tenantId }}', ''))))
   parameters:
     azureSubscription: ${{ parameters.azureSubscription }}
     script:
-      type: 'pscore'
-      script: | 
+      type: "pscore"
+      script: |
         $ErrorActionPreference = "Stop"
+        $accountInfo = az account show --query "{subscriptionId:id,tenantId:tenantId}" --output json | ConvertFrom-Json
 
-        Write-Host "##[group]Prepare Bicep deployment arguments"
-        Write-Host "##[section]Prepare Bicep deployment parameter"
-        # Set deployment scope
-        $deploymentScope = "${{ parameters.deploymentScope }}"
-        $deploymentName = "${{ parameters.deploymentName }}"
-        $bicepFile = "${{ parameters.file }}"
-        $overrideParameters = "${{ replace(parameters.overrideParameters, '\"', '`"') }}"
-        
-        # Remove line breaks and normalize whitespace in PowerShell
-        $overrideParameters = $overrideParameters -replace '\r?\n', ' ' -replace '\s+', ' '
-        $overrideParameters = $overrideParameters.Trim()
-
-        # Build deployment command based on scope
-        $deploymentCmd = @()
-
-        switch ($deploymentScope) {
-            "Subscription" {
-                $deploymentCmd += "az", "deployment", "sub", "create"
-                $deploymentCmd += "--location", "${{ parameters.location }}"
-            }
-            "ResourceGroup" {
-                $deploymentCmd += "az", "deployment", "group", "create"
-                $deploymentCmd += "--resource-group", "${{ parameters.resourceGroupName }}"
-            }
-            "ManagementGroup" {
-                $deploymentCmd += "az", "deployment", "mg", "create"
-                $deploymentCmd += "--management-group-id", "${{ parameters.managementGroupId }}"
-                $deploymentCmd += "--location", "${{ parameters.location }}"
-            }
-            default {
-                $deploymentCmd += "az", "deployment", "tenant", "create"
-                $deploymentCmd += "--location", "${{ parameters.location }}"
-            }
+        if ($null -eq $accountInfo -or [string]::IsNullOrWhiteSpace($accountInfo.subscriptionId) -or [string]::IsNullOrWhiteSpace($accountInfo.tenantId)) {
+            throw "Unable to resolve subscription and tenant IDs from Azure service connection."
         }
+        Write-Host "##vso[task.setvariable variable=BicepDeploy.SubscriptionId]$($accountInfo.subscriptionId)"
+        Write-Host "##vso[task.setvariable variable=BicepDeploy.TenantId]$($accountInfo.tenantId)"
+      displayName: "Resolve subscription/tenant IDs"
 
-        Write-Host "##[section]Prepare override parameters"
-        # Add common parameters
-        $deploymentCmd += "--name", $deploymentName
-        $deploymentCmd += "--template-file", $bicepFile
-        $deploymentCmd += "--no-prompt"
-        $deploymentCmd += "--output", "json"
+- task: BicepDeploy@0
+  name: bicepDeploy
+  displayName: "Deploy Bicep Resources"
+  inputs:
+    ${{ if ne(parameters.type, '') }}:
+      type: ${{ parameters.type }}
+    ${{ if ne(parameters.operation, '') }}:
+      operation: ${{ parameters.operation }}
+    name: ${{ parameters.deploymentName }}
+    description: ${{ parameters.deploymentDescription }}
+    azureResourceManagerConnection: ${{ parameters.azureSubscription }}
+    templateFile: ${{ parameters.file }}
+    parameters: "$(BicepDeploy.ParametersJson)"
+    ${{ if eq(parameters.type, 'deploymentStack') }}:
+      ${{ if ne(parameters.actionOnUnmanageResources, '') }}:
+        actionOnUnmanageResources: ${{ parameters.actionOnUnmanageResources }}
+      ${{ if ne(parameters.denySettingsMode, '') }}:
+        denySettingsMode: ${{ parameters.denySettingsMode }}
+        denySettingsApplyToChildScopes: ${{ parameters.denySettingsApplyToChildScopes }}
+      ${{ if ne(parameters.bypassStackOutOfSyncError, '') }}:
+        bypassStackOutOfSyncError: ${{ parameters.bypassStackOutOfSyncError }}
+      ${{ if ne(parameters.actionOnUnmanageResourceGroups, '') }}:
+        actionOnUnmanageResourceGroups: ${{ parameters.actionOnUnmanageResourceGroups }}
+      ${{ if ne(parameters.actionOnUnmanageManagementGroups, '') }}:
+        actionOnUnmanageManagementGroups: ${{ parameters.actionOnUnmanageManagementGroups }}
+      ${{ if ne(parameters.denySettingsExcludedActions, '') }}:
+        denySettingsExcludedActions: ${{ parameters.denySettingsExcludedActions }}
+      ${{ if ne(parameters.denySettingsExcludedPrincipals, '') }}:
+        denySettingsExcludedPrincipals: ${{ parameters.denySettingsExcludedPrincipals }}
+      ${{ if ne(parameters.stackTags, '') }}:
+        tags: ${{ parameters.stackTags }}
+    ${{ if eq(parameters.deploymentScope, 'ResourceGroup') }}:
+      scope: "resourceGroup"
+      resourceGroupName: ${{ parameters.resourceGroupName }}
+      ${{ if ne(parameters.subscriptionId, '') }}:
+        subscriptionId: ${{ parameters.subscriptionId }}
+      ${{ if eq(parameters.subscriptionId, '') }}:
+        subscriptionId: "$(BicepDeploy.SubscriptionId)"
+    ${{ if eq(parameters.deploymentScope, 'Subscription') }}:
+      scope: "subscription"
+      location: ${{ parameters.location }}
+      ${{ if ne(parameters.subscriptionId, '') }}:
+        subscriptionId: ${{ parameters.subscriptionId }}
+      ${{ if eq(parameters.subscriptionId, '') }}:
+        subscriptionId: "$(BicepDeploy.SubscriptionId)"
+    ${{ if eq(parameters.deploymentScope, 'ManagementGroup') }}:
+      scope: "managementGroup"
+      managementGroupId: ${{ parameters.managementGroupId }}
+      location: ${{ parameters.location }}
+    ${{ if eq(parameters.deploymentScope, 'Tenant') }}:
+      scope: "tenant"
+      location: ${{ parameters.location }}
+      ${{ if ne(parameters.tenantId, '') }}:
+        tenantId: ${{ parameters.tenantId }}
+      ${{ if eq(parameters.tenantId, '') }}:
+        tenantId: "$(BicepDeploy.TenantId)"
 
-        # Add override parameters if provided
-        if (-not [string]::IsNullOrEmpty($overrideParameters)) {
-            Write-Host "Raw override parameters: $overrideParameters"
-            
-            # Clean up the parameters string first
-            $cleanParams = $overrideParameters.Trim()
-            Write-Host "Cleaned parameters: $cleanParams"
-            
-            # Parse parameters while respecting both backtick-escaped quotes and regular quotes
-            $parameterList = @()
-            $currentParam = ""
-            $inQuotes = $false
-            $i = 0
-            $braceCount = 0
-            $bracketCount = 0
-            
-            while ($i -lt $cleanParams.Length) {
-                $char = $cleanParams[$i]
-                
-                # Handle escaped characters (backtick escapes)
-                if ($char -eq '`' -and ($i + 1) -lt $cleanParams.Length) {
-                    $nextChar = $cleanParams[$i + 1]
-                    if ($nextChar -eq '"') {
-                        # This is an escaped quote - add both characters and toggle quote state
-                        $currentParam += $char + $nextChar
-                        $inQuotes = -not $inQuotes
-                        $i += 2  # Skip next character since we processed it
-                        continue
-                    }
-                }
-                elseif ($char -eq '"') {
-                    # Regular quote - toggle quote state
-                    $inQuotes = -not $inQuotes
-                    $currentParam += $char
-                }
-                elseif ($char -eq '{') {
-                    $braceCount++
-                    $currentParam += $char
-                }
-                elseif ($char -eq '}') {
-                    $braceCount--
-                    $currentParam += $char
-                }
-                elseif ($char -eq '[') {
-                    $bracketCount++
-                    $currentParam += $char
-                }
-                elseif ($char -eq ']') {
-                    $bracketCount--
-                    $currentParam += $char
-                }
-                elseif ($char -eq ' ' -and -not $inQuotes -and $braceCount -eq 0 -and $bracketCount -eq 0) {
-                    # Space outside quotes and outside JSON structures - parameter boundary
-                    if ($currentParam.Trim()) {
-                        $parameterList += $currentParam.Trim()
-                        Write-Host "Found parameter: $($currentParam.Trim())"
-                    }
-                    $currentParam = ""
-                }
-                else {
-                    $currentParam += $char
-                }
-                
-                $i++
-            }
-            
-            # Add the last parameter if any
-            if ($currentParam.Trim()) {
-                $parameterList += $currentParam.Trim()
-                Write-Host "Found final parameter: $($currentParam.Trim())"
-            }
-            
-            # Process each parameter to handle JSON minimization if needed
-            $finalParameterList = @()
-            foreach ($param in $parameterList) {
-                if ($param -match '^(\w+)=(.+)$') {
-                    $paramName = $matches[1]
-                    $paramValue = $matches[2]
-                    
-                    # Check if the value looks like JSON (starts with { or [, ends with } or ])
-                    if ($paramValue -match '^[\s]*[{\[].*[}\]][\s]*$') {
-                        try {
-                            # Remove line breaks and extra whitespace from JSON string
-                            $cleanJsonContent = $paramValue -replace '\r?\n', '' -replace '\s+', ' '
-                            $cleanJsonContent = $cleanJsonContent.Trim()
-                            
-                            # Parse and minimize JSON
-                            $parsedJson = $cleanJsonContent | ConvertFrom-Json
-                            $minimizedJson = $parsedJson | ConvertTo-Json -Compress
-                            $finalParameterList += "$paramName=$minimizedJson"
-                            Write-Host "Processed JSON parameter: $paramName (minimized from $($cleanJsonContent.Length) to $($minimizedJson.Length) chars)"
-                        }
-                        catch {
-                            # If JSON parsing fails, clean up whitespace and wrap in quotes
-                            $cleanValue = $paramValue -replace '\r?\n', '' -replace '\s+', ' '
-                            $cleanValue = $cleanValue.Trim()
-                            if ($cleanValue -notmatch '^".*"$') {
-                                $finalParameterList += "$paramName=`"$cleanValue`""
-                            } else {
-                                $finalParameterList += "$paramName=$cleanValue"
-                            }
-                            Write-Host "Could not parse as JSON, keeping as cleaned string: $paramName"
-                        }
-                    }
-                    elseif ($paramValue -match '^".*"$') {
-                        # Already quoted string, keep as-is
-                        $finalParameterList += $param
-                        Write-Host "Processed quoted parameter: $paramName"
-                    }
-                    else {
-                        # Unquoted value, wrap in quotes if it contains spaces
-                        if ($paramValue -match '\s') {
-                            $finalParameterList += "$paramName=`"$paramValue`""
-                        } else {
-                            $finalParameterList += $param
-                        }
-                        Write-Host "Processed unquoted parameter: $paramName"
-                    }
-                }
-                else {
-                    # Malformed parameter, keep as-is
-                    $finalParameterList += $param
-                    Write-Host "Keeping malformed parameter as-is: $param"
-                }
-            }
-            
-            Write-Host "Final parameter list: $($finalParameterList -join ' | ')"
-            
-            $deploymentCmd += "--parameters"
-            $deploymentCmd += $finalParameterList
-        }
-        Write-Host "##[endgroup]"
+- pwsh: |
+    $ErrorActionPreference = "Stop"
 
-        Write-Host "##[section]Bicep deployment"
+    $internalVariables = @(
+      'BICEPDEPLOY_PARAMETERSJSON',
+      'BICEPDEPLOY_SUBSCRIPTIONID',
+      'BICEPDEPLOY_TENANTID'
+    )
 
-        # Execute deployment and capture output
-        Write-Host "##[command]$($deploymentCmd -join ' ')"
-        $deploymentOutput = & $deploymentCmd[0] $deploymentCmd[1..($deploymentCmd.Length-1)]
+    $outputs = [ordered]@{}
+    $bicepOutputVariables = Get-ChildItem Env: | Where-Object {
+      $_.Name.StartsWith('BICEPDEPLOY_') -and
+      -not ($internalVariables -contains $_.Name)
+    }
 
-        if ($LASTEXITCODE -ne 0) {
-            throw "Deployment failed with exit code $LASTEXITCODE"
-        }
+    foreach ($outputVar in $bicepOutputVariables) {
+      $outputName = $outputVar.Name.Substring('BICEPDEPLOY_'.Length).ToLowerInvariant()
+      $outputs[$outputName] = @{ value = $outputVar.Value }
+    }
 
-        # Parse deployment output as JSON
-        $deploymentResult = $deploymentOutput | ConvertFrom-Json
-        $outputs = $deploymentResult.properties.outputs
+    Write-Host "##[group]Build legacy output variables"
+    Write-Host "BicepDeploy outputs discovered: $($outputs.Keys -join ', ')"
 
-        # URL encode the deploymentResult.id
-        function UrlEncode([string]$str) {
-            [System.Net.WebUtility]::UrlEncode($str)
-        }
-        $encodedDeploymentId = UrlEncode $deploymentResult.id
+    $allOutputsVariableName = "${{ parameters.deploymentOutputs }}"
+    $allOutputsJson = $outputs | ConvertTo-Json -Compress -Depth 100
+    Write-Host "##vso[task.setvariable variable=$allOutputsVariableName]$allOutputsJson"
 
-        $deploymentDetailsUrl = "https://portal.azure.com/#blade/HubsExtension/DeploymentDetailsBlade/overview/id/$encodedDeploymentId"
-        Write-Host "Deployment details URL: $deploymentDetailsUrl"
+    foreach ($output in $outputs.GetEnumerator()) {
+      $outputName = $output.Key
+      $outputValue = $output.Value.value
 
-        if ($null -eq $outputs) {
-            $outputs = @{}
-        }
+      $nameVariableName = "$allOutputsVariableName.$outputName.name"
+      $valueVariableName = "$allOutputsVariableName.$outputName.value"
 
-        Write-Host "##[group]Build deployment outputs variables"
-        Write-Host "Deployment outputs: $($outputs | ConvertTo-Json -Compress)"
+      Write-Host "##vso[task.setvariable variable=$nameVariableName]$outputName"
+      Write-Host "##vso[task.setvariable variable=$valueVariableName]$outputValue"
+    }
 
-        # Create JSON string with all outputs (similar to deploymentOutputs variable)
-        $allOutputsJson = $outputs | ConvertTo-Json -Compress
-        $allOutputsVariableName = "${{ parameters.deploymentOutputs }}"
-        Write-Host "##vso[task.setvariable variable=$allOutputsVariableName]$allOutputsJson"
-
-        # Create individual variables for each output
-        if ($outputs -and $outputs.PSObject.Properties.Count -gt 0) {
-            foreach ($output in $outputs.PSObject.Properties) {
-                $outputName = $output.Name
-                $outputValue = $output.Value.value
-                
-                # Create structured variables with name and value
-                $nameVariableName = "$allOutputsVariableName.$outputName.name"
-                $valueVariableName = "$allOutputsVariableName.$outputName.value"
-                
-                Write-Host "##vso[task.setvariable variable=$nameVariableName]$outputName"
-                Write-Host "##vso[task.setvariable variable=$valueVariableName]$outputValue"
-                Write-Host "Created variable: $nameVariableName = $outputName"
-                Write-Host "Created variable: $valueVariableName = $outputValue"
-            }
-        }
-
-        Write-Host "##[endgroup]"
-
-        Write-Host "Bicep deployment completed successfully"
-      displayName: "Deploy Bicep Resources"
+    Write-Host "##[endgroup]"
+  displayName: "Build legacy output variables"

--- a/pipelines/lib/bicep-deploy.yml
+++ b/pipelines/lib/bicep-deploy.yml
@@ -189,11 +189,12 @@ parameters:
   default: ""
 
 steps:
-- pwsh: |
-    Write-Host "##vso[task.logissue type=error]Template resource files are not configured. Make sure to call `use-template-files.yml` first."
-    exit 1
-  condition: and(succeeded(), eq(variables.almguruTemplateFilesPath, ''))
-  displayName: "Fail if template files are not configured"
+- ${{ if parameters.useLegacyOverrideParameters }}:
+  - pwsh: |
+      Write-Host "##vso[task.logissue type=error]Template resource files are not configured. Make sure to call ``use-template-files.yml`` first."
+      exit 1
+    condition: and(succeeded(), eq(variables.almguruTemplateFilesPath, ''))
+    displayName: "Fail if template files are not configured"
 
 - ${{ if parameters.useLegacyOverrideParameters }}:
   - template: azure-cli.yml

--- a/pipelines/lib/bicep-deploy.yml
+++ b/pipelines/lib/bicep-deploy.yml
@@ -291,60 +291,11 @@ steps:
       ${{ if eq(parameters.tenantId, '') }}:
         tenantId: "$(BicepDeploy.TenantId)"
 
-- pwsh: |
-    $ErrorActionPreference = "Stop"
-
-    $internalVariables = @(
-      'BICEPDEPLOY_PARAMETERSJSON',
-      'BICEPDEPLOY_SUBSCRIPTIONID',
-      'BICEPDEPLOY_TENANTID'
-    )
-
-    $outputs = [ordered]@{}
-    $bicepOutputVariables = Get-ChildItem Env: | Where-Object {
-      $_.Name.StartsWith('BICEPDEPLOY_') -and
-      -not ($internalVariables -contains $_.Name)
-    }
-
-    foreach ($outputVar in $bicepOutputVariables) {
-      $outputName = $outputVar.Name.Substring('BICEPDEPLOY_'.Length).ToLowerInvariant()
-      $outputs[$outputName] = @{ value = $outputVar.Value }
-    }
-
-    function Assert-SafeAzureDevOpsVariableName {
-      param(
-        [Parameter(Mandatory = $true)]
-        [string] $Name
-      )
-
-      # Allow only characters that are safe in Azure DevOps logging commands.
-      if ($Name -notmatch '^[A-Za-z0-9_.-]+$') {
-        throw "Unsafe Azure DevOps variable name detected: '$Name'. Allowed characters: letters, digits, underscore, dot, hyphen."
-      }
-    }
-
-    Write-Host "##[group]Build legacy output variables"
-    Write-Host "BicepDeploy outputs discovered: $($outputs.Keys -join ', ')"
-
-    $allOutputsVariableName = $env:LEGACY_DEPLOYMENT_OUTPUTS_VARIABLE
-    Assert-SafeAzureDevOpsVariableName -Name $allOutputsVariableName
-    $allOutputsJson = $outputs | ConvertTo-Json -Compress -Depth 100
-    Write-Host "##vso[task.setvariable variable=$allOutputsVariableName]$allOutputsJson"
-
-    foreach ($output in $outputs.GetEnumerator()) {
-      $outputName = $output.Key
-      $outputValue = $output.Value.value
-
-      $nameVariableName = "$allOutputsVariableName.$outputName.name"
-      $valueVariableName = "$allOutputsVariableName.$outputName.value"
-      Assert-SafeAzureDevOpsVariableName -Name $nameVariableName
-      Assert-SafeAzureDevOpsVariableName -Name $valueVariableName
-
-      Write-Host "##vso[task.setvariable variable=$nameVariableName]$outputName"
-      Write-Host "##vso[task.setvariable variable=$valueVariableName]$outputValue"
-    }
-
-    Write-Host "##[endgroup]"
+- task: PowerShell@2
   displayName: "Build legacy output variables"
-  env:
-    LEGACY_DEPLOYMENT_OUTPUTS_VARIABLE: ${{ parameters.deploymentOutputs }}
+  inputs:
+    targetType: "filePath"
+    filePath: "$(almguruTemplateFilesPath)/scripts/Set-LegacyBicepDeploymentOutputs.ps1"
+    arguments: >
+      -DeploymentOutputsPrefix '${{ replace(parameters.deploymentOutputs, '''', '''''') }}'
+    pwsh: true

--- a/scripts/ConvertTo-BicepDeploymentParametersJson.ps1
+++ b/scripts/ConvertTo-BicepDeploymentParametersJson.ps1
@@ -1,0 +1,125 @@
+<#
+.SYNOPSIS
+Converts bicep-deploy overrideParameters into a JSON object string for BicepDeploy@0.
+
+.DESCRIPTION
+Parses legacy overrideParameters in key=value format and converts them to a JSON object
+string for BicepDeploy@0. If OverrideParameters is empty, an empty object ({}) is produced.
+
+The script is pipeline-agnostic: it returns only the resulting JSON string to stdout.
+
+.PARAMETER OverrideParameters
+Override parameters string.
+
+#>
+param(
+    [string]$OverrideParameters = ''
+)
+
+$ErrorActionPreference = "Stop"
+
+$OverrideParameters = $OverrideParameters -replace '\r?\n', ' ' -replace '\s+', ' '
+$OverrideParameters = $OverrideParameters.Trim()
+
+if ([string]::IsNullOrWhiteSpace($OverrideParameters)) {
+    Write-Output '{}'
+    exit 0
+}
+
+# Split OverrideParameters while preserving quoted and JSON values.
+$parameterList = @()
+$currentParam = ''
+$inQuotes = $false
+$i = 0
+$braceCount = 0
+$bracketCount = 0
+
+while ($i -lt $OverrideParameters.Length) {
+    $char = $OverrideParameters[$i]
+
+    if ($char -eq '`' -and ($i + 1) -lt $OverrideParameters.Length) {
+        $nextChar = $OverrideParameters[$i + 1]
+        if ($nextChar -eq '"') {
+            $currentParam += $char + $nextChar
+            $inQuotes = -not $inQuotes
+            $i += 2
+            continue
+        }
+    }
+    elseif ($char -eq '"') {
+        $inQuotes = -not $inQuotes
+        $currentParam += $char
+    }
+    elseif ($char -eq '{') {
+        $braceCount++
+        $currentParam += $char
+    }
+    elseif ($char -eq '}') {
+        $braceCount--
+        $currentParam += $char
+    }
+    elseif ($char -eq '[') {
+        $bracketCount++
+        $currentParam += $char
+    }
+    elseif ($char -eq ']') {
+        $bracketCount--
+        $currentParam += $char
+    }
+    elseif ($char -eq ' ' -and -not $inQuotes -and $braceCount -eq 0 -and $bracketCount -eq 0) {
+        if ($currentParam.Trim()) {
+            $parameterList += $currentParam.Trim()
+        }
+        $currentParam = ''
+    }
+    else {
+        $currentParam += $char
+    }
+
+    $i++
+}
+
+if ($currentParam.Trim()) {
+    $parameterList += $currentParam.Trim()
+}
+
+$parameterObject = [ordered]@{}
+foreach ($param in $parameterList) {
+    if ($param -notmatch '^([^=\s]+)=(.+)$') {
+        throw "Invalid override parameter format '$param'. Expected 'name=value'."
+    }
+
+    $paramName = $matches[1]
+    $paramValue = $matches[2].Trim()
+    $decodedValue = $paramValue -replace '`"', '"'
+
+    if ($decodedValue.Length -ge 2 -and $decodedValue.StartsWith('"') -and $decodedValue.EndsWith('"')) {
+        $decodedValue = $decodedValue.Substring(1, $decodedValue.Length - 2)
+    }
+
+    if ($decodedValue -match '^[\s]*[{\[].*[}\]][\s]*$') {
+        try {
+            $parameterObject[$paramName] = $decodedValue | ConvertFrom-Json -Depth 100
+            continue
+        }
+        catch {
+            # Keep as string if the value is JSON-like but invalid JSON.
+        }
+    }
+
+    if ($decodedValue -match '^(?i:true|false)$') {
+        $parameterObject[$paramName] = [System.Convert]::ToBoolean($decodedValue)
+        continue
+    }
+
+    $numberValue = 0
+    if ([double]::TryParse($decodedValue, [System.Globalization.NumberStyles]::Float, [System.Globalization.CultureInfo]::InvariantCulture, [ref]$numberValue)) {
+        $parameterObject[$paramName] = $numberValue
+        continue
+    }
+
+    $parameterObject[$paramName] = $decodedValue
+}
+
+$parametersJson = $parameterObject | ConvertTo-Json -Compress -Depth 100
+Write-Output $parametersJson

--- a/scripts/Set-LegacyBicepDeploymentOutputs.ps1
+++ b/scripts/Set-LegacyBicepDeploymentOutputs.ps1
@@ -1,0 +1,69 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string] $DeploymentOutputsPrefix
+)
+
+<#
+.SYNOPSIS
+Builds legacy deployment output variables from BicepDeploy task outputs.
+
+.DESCRIPTION
+Finds BICEPDEPLOY_* environment variables produced by BicepDeploy@0 and publishes
+legacy output variables expected by existing template consumers.
+
+.PARAMETER DeploymentOutputsPrefix
+Variable prefix used for the legacy output object and nested output variables.
+#>
+
+$ErrorActionPreference = "Stop"
+
+function Assert-SafeAzureDevOpsVariableName {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $Name
+  )
+
+  if ($Name -notmatch '^[A-Za-z0-9_.-]+$') {
+    throw "Unsafe Azure DevOps variable name detected: '$Name'. Allowed characters: letters, digits, underscore, dot, hyphen."
+  }
+}
+
+$internalVariables = @(
+  'BICEPDEPLOY_PARAMETERSJSON',
+  'BICEPDEPLOY_SUBSCRIPTIONID',
+  'BICEPDEPLOY_TENANTID'
+)
+
+$outputs = [ordered]@{}
+$bicepOutputVariables = Get-ChildItem Env: | Where-Object {
+  $_.Name.StartsWith('BICEPDEPLOY_') -and
+  -not ($internalVariables -contains $_.Name)
+}
+
+foreach ($outputVar in $bicepOutputVariables) {
+  $outputName = $outputVar.Name.Substring('BICEPDEPLOY_'.Length).ToLowerInvariant()
+  $outputs[$outputName] = @{ value = $outputVar.Value }
+}
+
+Write-Host "##[group]Build legacy output variables"
+Write-Host "BicepDeploy outputs discovered: $($outputs.Keys -join ', ')"
+
+Assert-SafeAzureDevOpsVariableName -Name $DeploymentOutputsPrefix
+$allOutputsJson = $outputs | ConvertTo-Json -Compress -Depth 100
+Write-Host "##vso[task.setvariable variable=$DeploymentOutputsPrefix]$allOutputsJson"
+
+foreach ($output in $outputs.GetEnumerator()) {
+  $outputName = $output.Key
+  $outputValue = $output.Value.value
+
+  $nameVariableName = "$DeploymentOutputsPrefix.$outputName.name"
+  $valueVariableName = "$DeploymentOutputsPrefix.$outputName.value"
+  Assert-SafeAzureDevOpsVariableName -Name $nameVariableName
+  Assert-SafeAzureDevOpsVariableName -Name $valueVariableName
+
+  Write-Host "##vso[task.setvariable variable=$nameVariableName]$outputName"
+  Write-Host "##vso[task.setvariable variable=$valueVariableName]$outputValue"
+}
+
+Write-Host "##[endgroup]"


### PR DESCRIPTION
## Description
This change migrates `pipelines/lib/bicep-deploy.yml` from custom Azure CLI deployment command composition to native `BicepDeploy@0` inputs, while preserving backward compatibility for existing consumers. It also adds optional deployment stack support by passing stack-specific inputs through to `BicepDeploy@0` only when provided.

The template now keeps compatibility with legacy `overrideParameters` usage, supports direct JSON/YAML override formats, and preserves legacy output aliases while preferring native `$(bicepDeploy.<outputName>)` outputs.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code refactoring

## Branch Naming Check
- [ ] My branch follows the naming convention: `features/descriptive-name`
- [ ] If this is a bug fix, my branch follows: `bugfix/descriptive-name`
- [ ] If this is a hotfix, my branch follows: `hotfix/descriptive-name`

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have performed manual testing of the changes

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issues
N/A

## Additional Notes
- Stack-specific inputs are passthroughs without template-level allowed-values constraints, relying on `BicepDeploy@0` validation.
- Optional `type` and `operation` are forwarded only when non-empty, so task defaults apply when omitted.
- This repository's validation pipeline does not execute `bicep-deploy.yml` against Azure; that template is validated in consuming pipelines.