### PR TITLE
Add repository security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported Versions
+
+This repository is maintained on the `main` branch. Security fixes are provided for:
+
+| Version | Supported |
+| --- | --- |
+| `main` | ✅ |
+| Older branches/tags | ❌ |
+
+## Reporting a Vulnerability
+
+Please **do not open public issues** for suspected vulnerabilities.
+
+Use GitHub's private vulnerability reporting:
+
+1. Go to the **Security** tab in this repository.
+2. Select **Report a vulnerability**.
+3. Provide reproduction details, impact, and any suggested remediation.
+
+If private reporting is unavailable in your environment, open a regular issue with minimal details and ask maintainers for a private contact channel.
+
+## What to Include
+
+When reporting, include:
+
+1. A clear description of the issue and affected files/templates.
+2. Steps to reproduce.
+3. Potential impact.
+4. Suggested fix (if available).
+
+We will acknowledge reports as quickly as possible and coordinate remediation and disclosure.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -19,7 +19,7 @@ Use GitHub's private vulnerability reporting:
 2. Select **Report a vulnerability**.
 3. Provide reproduction details, impact, and any suggested remediation.
 
-If private reporting is unavailable in your environment, open a regular issue with minimal details and ask maintainers for a private contact channel.
+If private reporting is unavailable in your environment, please contact the maintainers via a private channel (for example, by emailing a repository owner/organization admin) and avoid sharing vulnerability details publicly.
 
 ## What to Include
 


### PR DESCRIPTION
## Description
Add a repository security policy so vulnerability reporters have a clear, private disclosure path instead of opening public issues. This improves responsible disclosure handling for this public templates repo.

The change adds `.github/SECURITY.md` with supported version scope (`main`), private reporting steps via the Security tab, a fallback path when private reporting is unavailable, and the minimum details maintainers need for triage.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Branch Naming Check
- [ ] My branch follows the naming convention: `features/descriptive-name`
- [ ] If this is a bug fix, my branch follows: `bugfix/descriptive-name`
- [ ] If this is a hotfix, my branch follows: `hotfix/descriptive-name`

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have performed manual testing of the changes

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issues
N/A

## Additional Notes
This is a documentation-only change that aligns the repository with GitHub security policy conventions for public projects.