### PR TITLE
Add repository security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported Versions
+
+This repository is maintained on the `main` branch. Security fixes are provided for:
+
+| Version | Supported |
+| --- | --- |
+| `main` | ✅ |
+| Older branches/tags | ❌ |
+
+## Reporting a Vulnerability
+
+Please **do not open public issues** for suspected vulnerabilities.
+
+Use GitHub's private vulnerability reporting:
+
+1. Go to the **Security** tab in this repository.
+2. Select **Report a vulnerability**.
+3. Provide reproduction details, impact, and any suggested remediation.
+
+If private reporting is unavailable in your environment, open a regular issue with minimal details and ask maintainers for a private contact channel.
+
+## What to Include
+
+When reporting, include:
+
+1. A clear description of the issue and affected files/templates.
+2. Steps to reproduce.
+3. Potential impact.
+4. Suggested fix (if available).
+
+We will acknowledge reports as quickly as possible and coordinate remediation and disclosure.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -19,7 +19,7 @@ Use GitHub's private vulnerability reporting:
 2. Select **Report a vulnerability**.
 3. Provide reproduction details, impact, and any suggested remediation.
 
-If private reporting is unavailable in your environment, open a regular issue with minimal details and ask maintainers for a private contact channel.
+If private reporting is unavailable in your environment, please contact the maintainers via a private channel (for example, by emailing a repository owner/organization admin) and avoid sharing vulnerability details publicly.
 
 ## What to Include
 


### PR DESCRIPTION
Adds .github/SECURITY.md with vulnerability reporting guidance and supported version policy for this public repo.