### PR TITLE
Update PSScriptAnalyzer workflow for Node 24 actions

### DIFF
--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -29,7 +29,7 @@ jobs:
     name: PSScriptAnalyzer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run PSScriptAnalyzer
         uses: microsoft/psscriptanalyzer-action@6b2948b1944407914a58661c49941824d149734f
@@ -44,6 +44,7 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v3
+        if: always() && hashFiles('results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Why
GitHub Actions is deprecating Node.js 20 on runners, and this workflow was still using action versions tied to older Node runtimes. This change updates the workflow so PSScriptAnalyzer reporting continues to work without runtime deprecation risk.

## What changed
- Updated `actions/checkout` from `@v4` to `@v6`.
- Updated `github/codeql-action/upload-sarif` from `@v3` to `@v4`.
- Made SARIF upload step robust with `if: always() && hashFiles('results.sarif') != ''` so upload is attempted whenever analysis produced output, including runs where analyzer findings fail the job.

## Notes for reviewers
- This is a workflow-only change scoped to `.github/workflows/powershell.yml`.
- The intent is to preserve code scanning visibility for PSScriptAnalyzer results while aligning with current GitHub Actions runtime requirements.