### PR TITLE
Allow dependabot prefix in branch naming check

### DIFF
--- a/.github/BRANCH_NAMING.md
+++ b/.github/BRANCH_NAMING.md
@@ -18,6 +18,7 @@ features/<descriptive-name>
 ### Other Branch Types
 - `hotfix/<issue-description>` - For urgent production fixes
 - `bugfix/<issue-description>` - For bug fixes
+- `dependabot/<dependency-update>` - For automated dependency updates
 - `docs/<documentation-update>` - For documentation updates
 - `chore/<maintenance-task>` - For maintenance and cleanup tasks
 

--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -11,7 +11,7 @@ jobs:
   check-branch-naming:
     runs-on: ubuntu-latest
     env:
-      ALLOWED_PREFIXES: "^(features|bugfix|hotfix|copilot)/"
+      ALLOWED_PREFIXES: "^(features|bugfix|hotfix|copilot|dependabot)/"
     steps:
       - name: Check branch naming convention
         env:
@@ -32,6 +32,7 @@ jobs:
             echo "  - bugfix/your-bug-fix"
             echo "  - hotfix/your-hotfix"
             echo "  - copilot/your-copilot-edits"
+            echo "  - dependabot/your-dependency-update"
             echo ""
             echo "Example: features/add-user-authentication"
             echo ""
@@ -63,6 +64,7 @@ jobs:
               - \`bugfix/\` - for bug fixes  
               - \`hotfix/\` - for urgent fixes
               - \`copilot/\` - for copilot updates
+              - \`dependabot/\` - for dependency updates
               
               ### Example
               \`\`\`bash


### PR DESCRIPTION
## Description
Dependabot PR branches use the `dependabot/` prefix, but the branch naming workflow rejected that prefix and blocked those automated updates. This change aligns the checker with Dependabot branch naming.

The branch regex now allows `dependabot/`, and the workflow failure output/comment guidance were updated to list the same prefix so the validation logic and user-facing instructions stay consistent.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Branch Naming Check
- [ ] My branch follows the naming convention: `features/descriptive-name`
- [x] If this is a bug fix, my branch follows: `bugfix/descriptive-name`
- [ ] If this is a hotfix, my branch follows: `hotfix/descriptive-name`

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed manual testing of the changes

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issues
N/A

## Additional Notes
N/A