### PR TITLE
Use native pwsh steps for legacy Bicep script execution

### DIFF
--- a/pipelines/lib/bicep-deploy.yml
+++ b/pipelines/lib/bicep-deploy.yml
@@ -281,12 +281,8 @@ steps:
       ${{ if eq(parameters.tenantId, '') }}:
         tenantId: "$(BicepDeploy.TenantId)"
 
-- task: PowerShell@2
+- pwsh: |
+    & "$(almguruTemplateFilesPath)/scripts/Set-LegacyBicepDeploymentOutputs.ps1" `
+      -DeploymentOutputsPrefix '${{ replace(parameters.deploymentOutputs, '''', '''''') }}'
   displayName: "Build legacy output variables"
   condition: and(succeeded(), ne(variables.almguruTemplateFilesPath, ''))
-  inputs:
-    targetType: "filePath"
-    filePath: "$(almguruTemplateFilesPath)/scripts/Set-LegacyBicepDeploymentOutputs.ps1"
-    arguments: >
-      -DeploymentOutputsPrefix '${{ replace(parameters.deploymentOutputs, '''', '''''') }}'
-    pwsh: true

--- a/pipelines/lib/bicep-deploy.yml
+++ b/pipelines/lib/bicep-deploy.yml
@@ -197,18 +197,12 @@ steps:
     displayName: "Fail if template files are not configured"
 
 - ${{ if parameters.useLegacyOverrideParameters }}:
-  - template: azure-cli.yml
-    parameters:
-      azureSubscription: ${{ parameters.azureSubscription }}
-      defaultScriptType: "pscore"
-      script:
-        type: "pscore"
-        script: |
-          $ErrorActionPreference = "Stop"
-          $parametersJson = & "$(almguruTemplateFilesPath)/scripts/ConvertTo-BicepDeploymentParametersJson.ps1" `
-            -OverrideParameters '${{ replace(parameters.overrideParameters, '''', '''''') }}'
-          Write-Host "##vso[task.setvariable variable=BicepDeploy.ParametersJson]$parametersJson"
-        displayName: "Convert legacy deployment parameters"
+  - pwsh: |
+      $ErrorActionPreference = "Stop"
+      $parametersJson = & "$(almguruTemplateFilesPath)/scripts/ConvertTo-BicepDeploymentParametersJson.ps1" `
+        -OverrideParameters '${{ replace(parameters.overrideParameters, '''', '''''') }}'
+      Write-Host "##vso[task.setvariable variable=BicepDeploy.ParametersJson]$parametersJson"
+    displayName: "Convert legacy deployment parameters"
 
 - ${{ if or(and(or(eq(parameters.deploymentScope, 'ResourceGroup'), eq(parameters.deploymentScope, 'Subscription')), eq(parameters.subscriptionId, '')), and(eq(parameters.deploymentScope, 'Tenant'), eq(parameters.tenantId, ''))) }}:
   - template: azure-cli.yml


### PR DESCRIPTION
This change removes unnecessary task/template indirection in the legacy Bicep parameter/output flow so these script-only operations run as native PowerShell steps.

The deployment template now uses `- pwsh:` for both legacy script calls:
- converting legacy `overrideParameters` into `BicepDeploy.ParametersJson`
- building legacy deployment output variables via `Set-LegacyBicepDeploymentOutputs.ps1`

This keeps behavior the same while making execution more consistent and easier to read: script-only work stays in native PowerShell steps, while Azure CLI templating remains only where Azure CLI is actually needed.