### PR TITLE
Use native pwsh steps for legacy Bicep script execution

### DIFF
--- a/pipelines/lib/bicep-deploy.yml
+++ b/pipelines/lib/bicep-deploy.yml
@@ -281,12 +281,8 @@ steps:
       ${{ if eq(parameters.tenantId, '') }}:
         tenantId: "$(BicepDeploy.TenantId)"
 
-- task: PowerShell@2
+- pwsh: |
+    & "$(almguruTemplateFilesPath)/scripts/Set-LegacyBicepDeploymentOutputs.ps1" `
+      -DeploymentOutputsPrefix '${{ replace(parameters.deploymentOutputs, '''', '''''') }}'
   displayName: "Build legacy output variables"
   condition: and(succeeded(), ne(variables.almguruTemplateFilesPath, ''))
-  inputs:
-    targetType: "filePath"
-    filePath: "$(almguruTemplateFilesPath)/scripts/Set-LegacyBicepDeploymentOutputs.ps1"
-    arguments: >
-      -DeploymentOutputsPrefix '${{ replace(parameters.deploymentOutputs, '''', '''''') }}'
-    pwsh: true

--- a/pipelines/lib/bicep-deploy.yml
+++ b/pipelines/lib/bicep-deploy.yml
@@ -200,9 +200,11 @@ steps:
   - pwsh: |
       $ErrorActionPreference = "Stop"
       $parametersJson = & "$(almguruTemplateFilesPath)/scripts/ConvertTo-BicepDeploymentParametersJson.ps1" `
-        -OverrideParameters '${{ replace(parameters.overrideParameters, '''', '''''') }}'
+        -OverrideParameters "$env:BICEPDEPLOY_LEGACY_OVERRIDE_PARAMETERS"
       Write-Host "##vso[task.setvariable variable=BicepDeploy.ParametersJson]$parametersJson"
     displayName: "Convert legacy deployment parameters"
+    env:
+      BICEPDEPLOY_LEGACY_OVERRIDE_PARAMETERS: ${{ parameters.overrideParameters }}
 
 - ${{ if or(and(or(eq(parameters.deploymentScope, 'ResourceGroup'), eq(parameters.deploymentScope, 'Subscription')), eq(parameters.subscriptionId, '')), and(eq(parameters.deploymentScope, 'Tenant'), eq(parameters.tenantId, ''))) }}:
   - template: azure-cli.yml
@@ -283,6 +285,8 @@ steps:
 
 - pwsh: |
     & "$(almguruTemplateFilesPath)/scripts/Set-LegacyBicepDeploymentOutputs.ps1" `
-      -DeploymentOutputsPrefix '${{ replace(parameters.deploymentOutputs, '''', '''''') }}'
+      -DeploymentOutputsPrefix "$env:BICEPDEPLOY_LEGACY_OUTPUT_PREFIX"
   displayName: "Build legacy output variables"
   condition: and(succeeded(), ne(variables.almguruTemplateFilesPath, ''))
+  env:
+    BICEPDEPLOY_LEGACY_OUTPUT_PREFIX: ${{ parameters.deploymentOutputs }}

--- a/pipelines/lib/bicep-deploy.yml
+++ b/pipelines/lib/bicep-deploy.yml
@@ -197,18 +197,12 @@ steps:
     displayName: "Fail if template files are not configured"
 
 - ${{ if parameters.useLegacyOverrideParameters }}:
-  - template: azure-cli.yml
-    parameters:
-      azureSubscription: ${{ parameters.azureSubscription }}
-      defaultScriptType: "pscore"
-      script:
-        type: "pscore"
-        script: |
-          $ErrorActionPreference = "Stop"
-          $parametersJson = & "$(almguruTemplateFilesPath)/scripts/ConvertTo-BicepDeploymentParametersJson.ps1" `
-            -OverrideParameters '${{ replace(parameters.overrideParameters, '''', '''''') }}'
-          Write-Host "##vso[task.setvariable variable=BicepDeploy.ParametersJson]$parametersJson"
-        displayName: "Convert legacy deployment parameters"
+  - pwsh: |
+      $ErrorActionPreference = "Stop"
+      $parametersJson = & "$(almguruTemplateFilesPath)/scripts/ConvertTo-BicepDeploymentParametersJson.ps1" `
+        -OverrideParameters '${{ replace(parameters.overrideParameters, '''', '''''') }}'
+      Write-Host "##vso[task.setvariable variable=BicepDeploy.ParametersJson]$parametersJson"
+    displayName: "Convert legacy deployment parameters"
 
 - ${{ if or(and(or(eq(parameters.deploymentScope, 'ResourceGroup'), eq(parameters.deploymentScope, 'Subscription')), eq(parameters.subscriptionId, '')), and(eq(parameters.deploymentScope, 'Tenant'), eq(parameters.tenantId, ''))) }}:
   - template: azure-cli.yml


### PR DESCRIPTION
This updates legacy Bicep script-only steps to run as native PowerShell for consistency and clarity.

## What changed
- Replaced the legacy parameter conversion call from `azure-cli.yml` with a direct `- pwsh:` step.
- Replaced the `PowerShell@2` legacy output-variable step with a direct `- pwsh:` invocation of `Set-LegacyBicepDeploymentOutputs.ps1`.

## Why
These steps do not require Azure CLI, so native PowerShell is the simpler and more consistent execution path while preserving behavior.