### PR TITLE
Add GitHub release stage for main pipeline runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ The testing pipeline runs automatically on:
 
 This ensures that all templates execute correctly and are ready for use in production pipelines.
 
+Successful builds from the `main` branch also create and tag a GitHub release by using `$(Build.BuildNumber)`. To enable that stage, configure a pipeline variable named `GitHubServiceConnection` with the GitHub service connection name to use for release publishing.
+
 ## Contributing
 
 We welcome contributions to improve these templates! Please follow our guidelines:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -613,3 +613,42 @@ stages:
                 Write-Host ""
                 Write-Host "📊 Detailed report available in Extensions tab and TestReports artifact"
               pwsh: true
+
+  - stage: CreateGitHubRelease
+    displayName: 'Create GitHub Release'
+    dependsOn:
+      - TestAzureCLI
+      - TestUseTemplateFiles
+      - TestDocker
+      - TestBuildDotNet
+      - TestScripts
+      - VerifyTemplateAccessibility
+      - TestSummary
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+    jobs:
+      - job: PublishRelease
+        displayName: 'Create and tag GitHub release'
+        steps:
+          - checkout: none
+
+          - task: PowerShell@2
+            displayName: 'Validate GitHub release configuration'
+            inputs:
+              targetType: 'inline'
+              script: |
+                if ([string]::IsNullOrWhiteSpace('$(GitHubServiceConnection)') -or '$(GitHubServiceConnection)' -eq '$(GitHubServiceConnection)') {
+                    Write-Host "##vso[task.logissue type=error]Pipeline variable 'GitHubServiceConnection' must be set to a GitHub service connection name."
+                    exit 1
+                }
+              pwsh: true
+
+          - task: GitHubRelease@1
+            displayName: 'Create GitHub release $(Build.BuildNumber)'
+            inputs:
+              gitHubConnection: '$(GitHubServiceConnection)'
+              repositoryName: '$(Build.Repository.Name)'
+              action: 'create'
+              target: '$(Build.SourceVersion)'
+              tagSource: 'userSpecifiedTag'
+              tag: '$(Build.BuildNumber)'
+              title: '$(Build.BuildNumber)'


### PR DESCRIPTION
## Description
This adds automated GitHub release publishing to the main Azure pipeline so successful `main` builds produce a tagged release version without manual steps. The release stage runs last, creates a GitHub release from the current commit, and uses `$(Build.BuildNumber)` as both the tag and release version/title.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Branch Naming Check
- [ ] My branch follows the naming convention: `features/descriptive-name`
- [ ] If this is a bug fix, my branch follows: `bugfix/descriptive-name`
- [ ] If this is a hotfix, my branch follows: `hotfix/descriptive-name`

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have performed manual testing of the changes

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issues
N/A

## Additional Notes
The new `CreateGitHubRelease` stage runs only when `Build.SourceBranch` is `refs/heads/main` and after all existing stages complete successfully. It validates that the `GitHubServiceConnection` pipeline variable is configured before running `GitHubRelease@1`.