### PR TITLE
fix: hardcode GitHub service connection name in GitHubRelease task

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The testing pipeline runs automatically on:
 
 This ensures that all templates execute correctly and are ready for use in production pipelines.
 
-Successful builds from the `main` branch also create and tag a GitHub release by using `$(Build.BuildNumber)`. To enable that stage, configure a pipeline variable named `GitHubServiceConnection` with the GitHub service connection name to use for release publishing.
+Successful builds from the `main` branch also create and tag a GitHub release by using `$(Build.BuildNumber)`. This repository's test pipeline uses the fixed GitHub service connection name `almguru` for that stage.
 
 ## Contributing
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -625,8 +625,6 @@ stages:
       - VerifyTemplateAccessibility
       - TestSummary
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
-    variables:
-      GitHubServiceConnection: 'almguru'
     jobs:
       - job: PublishRelease
         displayName: 'Create and tag GitHub release'
@@ -635,9 +633,8 @@ stages:
 
           - task: GitHubRelease@1
             displayName: 'Create GitHub release $(Build.BuildNumber)'
-            condition: and(succeeded(), ne(variables['GitHubServiceConnection'], ''))
             inputs:
-              gitHubConnection: '$(GitHubServiceConnection)'
+              gitHubConnection: 'almguru'
               repositoryName: '$(Build.Repository.Name)'
               action: 'create'
               target: '$(Build.SourceVersion)'


### PR DESCRIPTION
## Problem

After PR #62 merged, pipeline build #2540 failed immediately with:

> Job PublishRelease: Step GitHubRelease input gitHubConnection references service connection $(GitHubServiceConnection) which could not be found

Azure DevOps does **not** support runtime variable expansion for service connection names. The value `$(GitHubServiceConnection)` was passed literally to the task instead of being resolved to `almguru`.

## Fix

Remove the variable indirection and hardcode the service connection name `almguru` directly in the `GitHubRelease@1` task input.