### PR TITLE
ci: add never-run compile-time template validation job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -392,7 +392,7 @@ stages:
 
           - template: pipelines/lib/azure-cli.yml
             parameters:
-              azureSubscription: 'public-teamplates'
+              azureSubscription: 'public-templates'
               script:
                 type: 'bash'
                 location: 'inlineScript'
@@ -400,7 +400,7 @@ stages:
 
           - template: pipelines/lib/bicep-deploy.yml
             parameters:
-              azureSubscription: 'public-teamplates'
+              azureSubscription: 'public-templates'
               deploymentScope: 'Subscription'
               location: 'eastus'
               file: 'infra/compile-validation.bicep'
@@ -419,7 +419,7 @@ stages:
 
           - template: pipelines/lib/run-acceptance-tests.yml
             parameters:
-              azureSubscription: 'public-teamplates'
+              azureSubscription: 'public-templates'
               environmentName: 'CompileValidation'
               runtimeType: 'none'
               suiteName: 'Compile-time validation'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -378,6 +378,52 @@ stages:
                 Write-Host "##[section]All templates verified successfully"
               pwsh: true
 
+      # Compile-time validation: references all templates but never executes.
+      - job: CompileTimeTemplateValidation
+        displayName: 'Compile-time validation (never runs)'
+        condition: eq(1, 0)
+        steps:
+          - checkout: self
+
+          - template: pipelines/lib/use-template-files.yml
+            parameters:
+              repositoryResourceName: 'self'
+              repositoryLocalPath: 'template-compile-validation'
+
+          - template: pipelines/lib/azure-cli.yml
+            parameters:
+              azureSubscription: 'public-teamplates'
+              script:
+                type: 'bash'
+                location: 'inlineScript'
+                script: 'echo "compile-time validation"'
+
+          - template: pipelines/lib/bicep-deploy.yml
+            parameters:
+              azureSubscription: 'public-teamplates'
+              deploymentScope: 'Subscription'
+              location: 'eastus'
+              file: 'infra/compile-validation.bicep'
+
+          - template: pipelines/lib/docker.yml
+            parameters:
+              containerRegistry: ''
+              images: []
+
+          - template: pipelines/lib/build-dotnet.yml
+            parameters:
+              buildAction: 'build'
+              buildSpec: 'src/Sample.slnx'
+              testSpec: 'bin/**/*.Tests.dll'
+              zipAfterPublish: false
+
+          - template: pipelines/lib/run-acceptance-tests.yml
+            parameters:
+              azureSubscription: 'public-teamplates'
+              environmentName: 'CompileValidation'
+              runtimeType: 'none'
+              suiteName: 'Compile-time validation'
+
   # Summary stage
   - stage: TestSummary
     displayName: 'Test Summary'


### PR DESCRIPTION
## Description
This adds compile-time validation coverage for pipeline templates without running deployment/build operations. A dedicated `CompileTimeTemplateValidation` job was added under `VerifyTemplateAccessibility` with `condition: eq(1, 0)` and references all library templates to force template expansion and parameter binding checks.

Azure-bound template references use the existing `public-templates` service connection, and the Docker template is included in compile-only mode (`images: []`) so no Docker task is emitted.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Branch Naming Check
- [x] My branch follows the naming convention: `features/descriptive-name`
- [ ] If this is a bug fix, my branch follows: `bugfix/descriptive-name`
- [ ] If this is a hotfix, my branch follows: `hotfix/descriptive-name`

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have performed manual testing of the changes

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issues
N/A

## Additional Notes
This is intentionally a compile-time-only validation path. The job exists to ensure template references and parameter contracts stay valid while avoiding runtime side effects.
