### PR TITLE
Fix GitVersion tag detection in Azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -256,6 +256,7 @@ stages:
         steps:
           - checkout: self
             fetchDepth: 0 # Shallow Clone disabled to work with complicated branch structures
+            fetchTags: true # Ensure version source tags are available to GitVersion
             path: 's' # Force checkout to the 's' folder to allow multiple `- checkout:` steps in calling pipelines
 
           - task: gitversion-setup@4
@@ -266,7 +267,7 @@ stages:
           - task: gitversion-execute@4
             displayName: 'Calculate SemVer'
             inputs:
-              targetPath: '$(Build.SourcesDirectory)'
+              targetPath: '$(Build.Repository.LocalPath)'
               buildNumberFormat: '${GitVersion_FullSemVer}'
 
           - template: pipelines/lib/build-dotnet.yml


### PR DESCRIPTION
## Description
GitVersion was not consistently seeing repository tags in CI, which prevented expected version source resolution after tagging. This change makes tag availability explicit during checkout and points GitVersion to the repository-local path used by the agent.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Branch Naming Check
- [ ] My branch follows the naming convention: `features/descriptive-name`
- [x] If this is a bug fix, my branch follows: `bugfix/descriptive-name`
- [ ] If this is a hotfix, my branch follows: `hotfix/descriptive-name`

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have performed manual testing of the changes

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issues
N/A

## Additional Notes
Pipeline changes:
- `checkout: self` now includes `fetchTags: true`.
- `gitversion-execute@4` now uses `targetPath: $(Build.Repository.LocalPath)` instead of `$(Build.SourcesDirectory)`.

This makes behavior resilient to project-level source settings such as disabled tag sync and avoids path ambiguity.