### PR TITLE
Fix release stage access to computed version output

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -691,6 +691,7 @@ stages:
   - stage: CreateGitHubRelease
     displayName: 'Create GitHub Release'
     dependsOn:
+      - Setup
       - TestAzureCLI
       - TestUseTemplateFiles
       - TestDocker


### PR DESCRIPTION
## Description
CreateGitHubRelease was not receiving GitVersion_MajorMinorPatch reliably, which could produce a release without a version. This change ensures the release stage has access to Setup stage outputs by adding the missing direct stage dependency.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Branch Naming Check
- [ ] My branch follows the naming convention: features/descriptive-name
- [x] If this is a bug fix, my branch follows: bugfix/descriptive-name
- [ ] If this is a hotfix, my branch follows: hotfix/descriptive-name

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed manual testing of the changes

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issues
N/A

## Additional Notes
One-line pipeline fix: CreateGitHubRelease.dependsOn now includes Setup.